### PR TITLE
Use tree_sitter_language_pack

### DIFF
--- a/code_extractor/languages.py
+++ b/code_extractor/languages.py
@@ -5,7 +5,7 @@ Language detection and parser management for tree-sitter.
 import os
 from typing import Dict, Optional
 from tree_sitter import Language, Parser
-from tree_sitter_languages import get_language, get_parser
+from tree_sitter_language_pack import get_language, get_parser
 
 
 # Supported languages mapping

--- a/code_extractor/search_engine.py
+++ b/code_extractor/search_engine.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import os
 import fnmatch
 from tree_sitter import Node, Query
-from tree_sitter_languages import get_parser, get_language
+from tree_sitter_language_pack import get_parser, get_language
 
 from .models import SearchResult, SearchParameters
 from .file_reader import get_file_content

--- a/code_extractor/server.py
+++ b/code_extractor/server.py
@@ -17,7 +17,7 @@ except ImportError:
     sys.exit(1)
 
 try:
-    from tree_sitter_languages import get_parser
+    from tree_sitter_language_pack import get_parser
 except ImportError:
     print("Error: tree-sitter-languages not installed. Install with: pip install tree-sitter-languages", file=sys.stderr)
     sys.exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
     "mcp>=1.11.0",
-    "tree-sitter-languages-pack>=0.9.0",
+    "tree-sitter-language-pack>=0.9.0",
     "tree-sitter==0.21.3",
     "requests>=2.31.0",
     "cachetools>=5.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
     "mcp>=1.11.0",
-    "tree-sitter-languages>=1.10.2",
+    "tree-sitter-languages-pack>=0.9.0",
     "tree-sitter==0.21.3",
     "requests>=2.31.0",
     "cachetools>=5.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "mcp>=1.11.0",
     "tree-sitter-language-pack>=0.9.0",
-    "tree-sitter==0.21.3",
+    "tree-sitter==0.23.2",
     "requests>=2.31.0",
     "cachetools>=5.3.0",
 ]


### PR DESCRIPTION
I was not able to install the project and it looks like we're relying on the unmaintained [tree_sitter_languages](https://github.com/grantjenks/py-tree-sitter-languages) package rather than the maintained [tree_sitter_language_pack](https://github.com/Goldziher/tree-sitter-language-pack) fork. By using the `tree_sitter_language_pack` we avoid the CPython 3.1.3 compatibility error.